### PR TITLE
Check if initialised before lifecycle events

### DIFF
--- a/android/RCTChirpConnectModule.java
+++ b/android/RCTChirpConnectModule.java
@@ -266,7 +266,7 @@ public class RCTChirpConnectModule extends ReactContextBaseJavaModule implements
 
     @Override
     public void onHostResume() {
-        if (wasStarted) {
+        if (chirpConnect && wasStarted) {
             chirpConnect.start();
         }
     }
@@ -274,7 +274,9 @@ public class RCTChirpConnectModule extends ReactContextBaseJavaModule implements
     @Override
     public void onHostPause() {
         wasStarted = started;
-        chirpConnect.stop();
+        if (chirpConnect) {
+            chirpConnect.stop();
+        }
     }
 
     @Override

--- a/android/RCTChirpConnectModule.java
+++ b/android/RCTChirpConnectModule.java
@@ -49,8 +49,7 @@ public class RCTChirpConnectModule extends ReactContextBaseJavaModule implements
     private static final String TAG = "ChirpConnect";
     private ChirpConnect chirpConnect;
     private ReactContext context;
-    private boolean started = false;
-    private boolean wasStarted = false;
+    private boolean isStarted = false;
 
     @Override
     public String getName() {
@@ -176,8 +175,9 @@ public class RCTChirpConnectModule extends ReactContextBaseJavaModule implements
         ChirpError error = chirpConnect.start();
         if (error.getCode() > 0) {
             onError(context, error.getMessage());
+        } else {
+            isStarted = true;
         }
-        started = true;
     }
 
     /**
@@ -190,8 +190,9 @@ public class RCTChirpConnectModule extends ReactContextBaseJavaModule implements
         ChirpError error = chirpConnect.stop();
         if (error.getCode() > 0) {
             onError(context, error.getMessage());
+        } else {
+            isStarted = false;
         }
-        started = false;
     }
 
     /**
@@ -266,14 +267,13 @@ public class RCTChirpConnectModule extends ReactContextBaseJavaModule implements
 
     @Override
     public void onHostResume() {
-        if (chirpConnect && wasStarted) {
+        if (chirpConnect && isStarted) {
             chirpConnect.start();
         }
     }
 
     @Override
     public void onHostPause() {
-        wasStarted = started;
         if (chirpConnect) {
             chirpConnect.stop();
         }
@@ -281,7 +281,6 @@ public class RCTChirpConnectModule extends ReactContextBaseJavaModule implements
 
     @Override
     public void onHostDestroy() {
-        wasStarted = started;
         try {
             chirpConnect.close();
         } catch(IOException err) {}


### PR DESCRIPTION
**Who:** @shalin-jasani747
**Why:** Causes error if app is paused before initialising SDK
**What:**

- Check `chirpConnect` has been set before calling its methods in lifecycle events.

Closes: #12 